### PR TITLE
5.4 testing/updates

### DIFF
--- a/includes/views/admin.php
+++ b/includes/views/admin.php
@@ -11,14 +11,14 @@
 	<tr>
 		<th scope="row"><p><label for="<?php $this->field_id( 'post_info' ); ?>"><b><?php esc_html_e( 'Entry Meta (above content)', 'genesis-simple-edits' ); ?></b></label></p></th>
 		<td>
-			<p><input type="text" name="<?php $this->field_name( 'post_info' ); ?>" id="<?php $this->field_id( 'post_info' ); ?>" value="<?php echo esc_attr( $this->get_field_value( 'post_info' ) ); ?>" size="125" /></p>
+			<p><input type="text" class="regular-text" name="<?php $this->field_name( 'post_info' ); ?>" id="<?php $this->field_id( 'post_info' ); ?>" value="<?php echo esc_attr( $this->get_field_value( 'post_info' ) ); ?>" /></p>
 		</td>
 	</tr>
 
 	<tr>
 		<th scope="row"><p><label for="<?php $this->field_id( 'post_meta' ); ?>"><b><?php esc_html_e( 'Entry Meta (below content)', 'genesis-simple-edits' ); ?></b></label></p></th>
 		<td>
-			<p><input type="text" name="<?php $this->field_name( 'post_meta' ); ?>" id="<?php $this->field_id( 'post_meta' ); ?>" value="<?php echo esc_attr( $this->get_field_value( 'post_meta' ) ); ?>" size="125" /></p>
+			<p><input type="text"  class="regular-text" name="<?php $this->field_name( 'post_meta' ); ?>" id="<?php $this->field_id( 'post_meta' ); ?>" value="<?php echo esc_attr( $this->get_field_value( 'post_meta' ) ); ?>" /></p>
 
 			<p><small><a class="post-shortcodes-toggle" href="#"><?php esc_html_e( 'Show available entry meta shortcodes', 'genesis-simple-edits' ); ?></a></small></p>
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: nathanrice, studiopress, wpmuguru
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=5553118
 Tags: shortcodes, genesis, genesiswp, studiopress
 Requires at least: 5.0.0
-Tested up to: 5.2.2
+Tested up to: 5.4
 Stable tag: 2.3.0
 
 This plugin lets you edit the three most commonly modified areas in any Genesis theme: the post-info (byline), the post-meta, and the footer area.


### PR DESCRIPTION
<!-- A short but detailed summary of the changes. -->

<!-- Fixes #xxx. -->
I tested this on 5.4 and it is all working well. I included a fix for https://github.com/studiopress/genesis-simple-edits/issues/12 as well, which simply removes the hardcoded input field width, and uses the WP standard class for input fields instead. That fixes the width on tablets.

