### PR TITLE
Add deprecation notice to readme files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ This plugin lets you edit the three most commonly modified areas in any Genesis 
 ## DEPRECATION NOTICE
 This plugin is now deprecated and will no longer receive feature updates. The reason for deprecation is due to the Genesis Framework parent theme allowing similar functionality, which can be found in the WordPress dashboard under
 - Genesis → Theme Settings → Singular Content
-- Genesis → Theme Settings → Header/Footer Scripts
+- Genesis → Theme Settings → Footer

--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
+# Genesis Simple Edits
 
+This plugin lets you edit the three most commonly modified areas in any Genesis theme: the post-info (byline), the post-meta, and the footer area.
+
+## DEPRECATION NOTICE
+This plugin is now deprecated and will no longer receive feature updates. The reason for deprecation is due to the Genesis Framework parent theme allowing similar functionality, which can be found in the WordPress dashboard under
+- Genesis → Theme Settings → Singular Content
+- Genesis → Theme Settings → Header/Footer Scripts

--- a/README.md
+++ b/README.md
@@ -6,3 +6,6 @@ This plugin lets you edit the three most commonly modified areas in any Genesis 
 This plugin is now deprecated and will no longer receive feature updates. The reason for deprecation is due to the Genesis Framework parent theme allowing similar functionality, which can be found in the WordPress dashboard under
 - Genesis → Theme Settings → Singular Content
 - Genesis → Theme Settings → Footer
+
+For more information about how to use these features in Genesis Framework, see this article:
+https://my.studiopress.com/documentation/usage/genesis-features/edit-the-entry-meta-and-footer-text-with-genesis/

--- a/readme.txt
+++ b/readme.txt
@@ -8,6 +8,11 @@ Stable tag: 2.3.1
 
 This plugin lets you edit the three most commonly modified areas in any Genesis theme: the post-info (byline), the post-meta, and the footer area.
 
+== DEPRECATION NOTICE ==
+This plugin is now deprecated and will no longer receive feature updates. The reason for deprecation is due to the Genesis Framework parent theme allowing similar functionality, which can be found in the WordPress dashboard under
+- Genesis → Theme Settings → Singular Content
+- Genesis → Theme Settings → Header/Footer Scripts
+
 == Description ==
 
 This plugin creates a new Genesis settings page that allows you to modify the post-info (byline), post-meta, and footer area on any Genesis theme. Using text, shortcodes, and HTML in the textboxes provided in the admin screen, these three commonly modified areas are easily editable, without having to learn PHP or write functions, filters, or mess with hooks.

--- a/readme.txt
+++ b/readme.txt
@@ -11,7 +11,7 @@ This plugin lets you edit the three most commonly modified areas in any Genesis 
 == DEPRECATION NOTICE ==
 This plugin is now deprecated and will no longer receive feature updates. The reason for deprecation is due to the Genesis Framework parent theme allowing similar functionality, which can be found in the WordPress dashboard under
 - Genesis → Theme Settings → Singular Content
-- Genesis → Theme Settings → Header/Footer Scripts
+- Genesis → Theme Settings → Footer
 
 == Description ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -13,6 +13,9 @@ This plugin is now deprecated and will no longer receive feature updates. The re
 - Genesis → Theme Settings → Singular Content
 - Genesis → Theme Settings → Footer
 
+For more information about how to use these features in Genesis Framework, see this article:
+https://my.studiopress.com/documentation/usage/genesis-features/edit-the-entry-meta-and-footer-text-with-genesis/
+
 == Description ==
 
 This plugin creates a new Genesis settings page that allows you to modify the post-info (byline), post-meta, and footer area on any Genesis theme. Using text, shortcodes, and HTML in the textboxes provided in the admin screen, these three commonly modified areas are easily editable, without having to learn PHP or write functions, filters, or mess with hooks.


### PR DESCRIPTION
Fixes: #24 

Adds a deprecation notice to the readme.md for GitHub, and the readme.txt for WordPress.org.
 
### How to test
Code review. 

### Documentation
Will require documentation updates, notably to:
- https://my.studiopress.com/documentation/genesis-simple-edits/plugin-use/edit-entry-meta-and-footer-info-with-genesis-simple-edits/

cc @susannelson 

@dreamwhisper @nickcernis Do yyou have any knowledge about whether any of our child themes use this plugin in starter packs?

### Notes
Only readme updates — can be pushed to WP.org without a version bump or new zip.
